### PR TITLE
submit-job now accept query parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .lein-failures
 .lein-deps-sum
 .DS_Store
+*.iml

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,6 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [aleph "0.4.0"]
                  [cheshire "5.5.0"]]
-  :plugins [[lein-cljfmt "0.1.10"]]
+  :plugins [[lein-cljfmt "0.3.0"]]
   :autodoc {:name       "clj-jenkins"
             :page-title "clojure client for jenkins"})

--- a/src/clj_jenkins/core.clj
+++ b/src/clj_jenkins/core.clj
@@ -18,8 +18,9 @@
   [url & [opts]]
   (let [{:keys [username password]} *creds*]
     (-> url
-        (aleph-http/get (merge {:basic-auth [username password]
-                                :as         :json}
+        (aleph-http/get (merge (when (and username password)
+                                 {:basic-auth [username password]
+                                  :as         :json})
                                opts))
         deref
         :body)))
@@ -75,6 +76,6 @@
     (with-download-url build)))
 
 (defn submit-job
-  "schedule a new build of job-name"
-  [job-name]
-  (get-json (format "http://%s/job/%s/build" *jenkins* job-name)))
+  "schedule a new build of job-name. Extra parameters are sent as query parameters."
+  [job-name & {:as params}]
+  (apply get-json (format "http://%s/job/%s/build" *jenkins* job-name) {:query-params params}))


### PR DESCRIPTION
Extra parameters of submit-job function will be sent as query parameters.

Make credentials optional, do not send basic auth headers when no credentials is defined.