### PR TITLE
Add submit-parametric-job

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,12 @@
-(defproject clj-jenkins "0.1.5"
+(defproject clj-jenkins "0.1.6"
   :description "Clojure client for Jenkins"
   :url "https://github.com/smallrivers/clj-jenkins"
   :license {:name "MIT public License"
             :url  "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [aleph "0.4.0"]
-                 ; because of https://github.com/ztellman/aleph/issues/189
-                 [potemkin "0.4.3"]
-                 [cheshire "5.5.0"]]
-  :plugins [[lein-cljfmt "0.4.1"]]
+                 [aleph "0.4.1"]
+                 [cheshire "5.6.3"]]
+  :plugins [[lein-cljfmt "0.5.6"]]
   :autodoc {:name       "clj-jenkins"
             :page-title "clojure client for jenkins"})

--- a/src/clj_jenkins/core.clj
+++ b/src/clj_jenkins/core.clj
@@ -13,7 +13,7 @@
              *creds*   ~creds]
      (do ~@body)))
 
-(defn get-json
+(defn- get-json
   "Execute a GET query with optional basic-auth and return json"
   [url & [opts]]
   (let [{:keys [username password]} *creds*]
@@ -79,3 +79,10 @@
   "schedule a new build of job-name. Extra parameters are sent as query parameters."
   [job-name & {:as params}]
   (apply get-json (format "http://%s/job/%s/build" *jenkins* job-name) {:query-params params}))
+
+(defn submit-parametric-job
+  "schedule a new build of job-name configured with build parameters
+  (https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Build).
+  Extra parameters are sent as query parameters."
+  [job-name & {:as params}]
+  (apply get-json (format "http://%s/job/%s/buildWithParameters" *jenkins* job-name) {:query-params params}))


### PR DESCRIPTION
Used when a job has build parameters as defined on https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Build