### PR TITLE
Bump dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,9 @@
   :license {:name "MIT public License"
             :url  "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [aleph "0.4.1"]
-                 [cheshire "5.6.3"]]
+                 [org.clojure/tools.logging "0.4.0"]
+                 [aleph "0.4.3"]
+                 [cheshire "5.8.0"]]
   :plugins [[lein-cljfmt "0.5.6"]]
   :autodoc {:name       "clj-jenkins"
             :page-title "clojure client for jenkins"})


### PR DESCRIPTION
Aleph 0.4.1 doesn't build with clojure 1.9.0-beta2!